### PR TITLE
Simple notifications

### DIFF
--- a/hearts/static/hearts/css/style.css
+++ b/hearts/static/hearts/css/style.css
@@ -445,3 +445,25 @@ div[id^="trick-card-"] img {
 #leave-game:hover {
     opacity: 0.5;
 }
+
+/* Notifications */
+#player-notifications {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 300px;
+}
+.player-notification {
+    position: absolute;
+    transition: 1s;
+    opacity: 0;
+    transform: translateX(-50%) translateY(-50%);
+    color: white;
+    padding: 3px 5px;
+    background: transparent;
+}
+.player-notification.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(600%);
+    background: rgba(0, 0, 0, 0.8);
+}

--- a/hearts/templates/hearts/game.html
+++ b/hearts/templates/hearts/game.html
@@ -12,6 +12,8 @@
 
     <div id="current-turn-token"></div>
 
+    <div id="player-notifications"></div>
+
     <div id="trick">
         <div id="action-button"></div>
         <div id="trick-card-bottom"><div class="trick-card-placeholder"></div></div>
@@ -42,6 +44,7 @@
     const loader = document.getElementById('loader');
     const actionButton = document.getElementById('action-button');
     const currentTurnToken = document.getElementById('current-turn-token');
+    const playerNotifications = document.getElementById('player-notifications');
     const leaveGameButton = document.getElementById('leave-game');
 
     const playerBottom = document.getElementById('player-bottom');
@@ -179,6 +182,7 @@
         }).join('');
     };
 
+    // Function to send an action to the backed.
     const callAction = (action, requestData, callback) => {
         fetch('/game/{{ game_id }}/', {
             method: 'POST',
@@ -228,14 +232,7 @@
         callAction(currentAction, requestData, callback);
     }
 
-    leaveGameButton.onclick = () => {
-        callAction('leave-game', {}, () => {
-            window.location.href = '/';
-        });
-    }
-
-    const updateGameState = () => getGameState(handleGameStateUpdate);
-
+    // Fetch the state of the game from the logged in players perspective.
     const getGameState = (callback) => {
         loader.classList.remove('hide');
         fetch('/game/{{ game_id }}/state', {
@@ -255,20 +252,78 @@
         });
     }
 
+    // Load and handle game game state.
+    const updateGameState = () => getGameState(handleGameStateUpdate);
+
     // Update the game state on page load.
     updateGameState();
 
-    // Setup live updates. Try WS, fallback to SSE, fallback further to polling.
-    if (typeof(WebSocket) !== 'undefined') {
-        const ws = new WebSocket(`ws://${window.location.host}/game/{{ game_id }}/socket/`)
+    /*********************/
+    /* Leave Game Button */
+    /*********************/
+    leaveGameButton.onclick = () => {
+        callAction('leave-game', {}, () => {
+            window.location.href = '/';
+        });
+    }
+
+    /*****************/
+    /* Notifications */
+    /*****************/
+    const handleNotification = (notification) => {
+        const notificationNode = document.createElement('div');
+        notificationNode.innerText = notification.text;
+        notificationNode.classList.add('player-notification');
+        playerNotifications.appendChild(notificationNode);
+        window.setTimeout(() => {
+            notificationNode.classList.add('show');
+        }, 10);
+        window.setTimeout(() => {
+            playerNotifications.removeChild(notificationNode);
+        }, 2000);
+    }
+
+    /**************/
+    /* WebSockets */
+    /**************/
+    const connectToWebSocket = () => {
+        const ws = new WebSocket(`ws://${window.location.host}/game/{{ game_id }}/socket/`);
+        // Handle incoming ws messages. Route to appropriate handles.
         ws.onmessage = (event) => {
-            const data = JSON.parse(event.data)
-            console.log('Received WS');
-            handleGameStateUpdate(data)
-        }
+            const data = JSON.parse(event.data);
+            console.log('Received WS', data.action);
+            switch (data.action) {
+                case 'update-game-state':
+                    handleGameStateUpdate(data.payload);
+                    break;
+                case 'notify-user':
+                    handleNotification(data.payload);
+                    break;
+                default:
+                    console.error('Unknown websocket action received', data.action)
+                    break;
+            }
+        };
+
+        // Handle closed connection. Try to reconnect after some time;
         ws.onclose = () => {
-            console.error('Socket closed');
-        }
+            console.error('Socket closed. Attempting to reconnect');
+            window.setTimeout(connectToWebSocket, 1000);
+        };
+
+        // Handle connection error. Close and try again.
+        ws.onerror = (error) => {
+            console.error('Socket error', error);
+            ws.close();
+        };
+    };
+
+    /*********************************************************/
+    /* Live updating UI                                      */
+    /* Try WS, fallback to SSE, fallback further to polling. */
+    /*********************************************************/
+    if (typeof(WebSocket) !== 'undefined') {
+        connectToWebSocket();
     } else if (typeof(EventSource) !== 'undefined') {
         const sse = new EventSource('/game/{{ game_id }}/state/stream/');
         sse.onmessage = (event) => {
@@ -282,9 +337,6 @@
             updateGameState();
         }, 500);
     }
-
-    /* Play Cards */
-
 </script>
 
 {% endblock %}


### PR DESCRIPTION
## Notifications
![Screen Recording 2022-09-21 at 10 13 51 AM](https://user-images.githubusercontent.com/11714588/191569655-51e2da97-b81e-4b6e-b12c-b216d0c1cb63.gif)

The game currently has no way to give feedback to the user. Now that we have websockets, a simple notification system is easy to setup.

### Approach

- First, the sending of websocket messages had to be made so we could send specific messages to  a single connection rather than blasting out a message to everyone connected to the game. The change here is the new `game_<game_id>_player_<player_id>` websocket groups. So when a player joins a game, they join a websocket group specific to them. This allows us to send a message like "Your turn" and be sure we aren't sending it to all players.
- Now that we are sending two different types of messages over websockets (game state updates and notifications) we need a way for the front end to differentiate them. Now the front end receives a websocket message that contains an `action` string and a `payload` dict. The front end then can handle each action differently.
- The actual UI for the notifications are just small pieces of text with a dark background that float around the middle of the screen. I'm not in love with this design so let me know if you have better or ideas, or better yet, go ahead and just change them if you want to.
